### PR TITLE
fix the definition of canonical index

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN add-apt-repository ppa:plt/racket
 RUN apt-get update -y && apt-get install -y clang-format clang-tidy clang-tools clang clangd libc++-dev libc++1 libc++abi-dev \
             libc++abi1 libclang-dev libclang1 liblldb-dev libomp-dev libomp5 lld lldb \
             llvm-dev llvm-runtime llvm python-clang mcpp cmake racket build-essential mpich z3 \
-            git python3-pip sqlite3 ninja-build
+            git python3-pip sqlite3 ninja-build valgrind apt-utils
 RUN raco setup --doc-index --force-user-docs
 RUN raco pkg install --batch --deps search-auto binaryio graph
 
@@ -19,7 +19,9 @@ ENV CXX=mpicxx
 COPY . /slog
 
 # build backend
-RUN cd /slog/backend ; rm -rf build ; cmake -Bbuild -DCMAKE_BUILD_TYPE=Release . && cd build ; make -j8;
+RUN cd /slog/backend ; rm -rf build ; \ 
+    cmake --no-warn-unused-cli -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER:FILEPATH=/usr/bin/mpicc -H/slog/backend -B/slog/backend/build -G Ninja ; \
+    cmake --build /slog/backend/build --config Release --target all -j --
 
 WORKDIR /slog
 RUN pip3 install -r requirements.txt

--- a/backend/src/relation/balanced_hash_relation.cpp
+++ b/backend/src/relation/balanced_hash_relation.cpp
@@ -570,6 +570,10 @@ void relation::load_data_from_file_with_offset()
 
 void relation::load_data_from_file()
 {
+    std::cout << "relation with tag :" << this->get_intern_tag() << " "
+              << "filename :" << this->get_filename() << " "
+            //   << "c++ object " << this
+              << "start normal IO" << std::endl;
     /// reading from file
     if (initailization_type != -1)
     {
@@ -717,6 +721,7 @@ void relation::initialize_relation(mpi_comm& mcomm, std::map<u64, u64>& intern_m
     // TODO: ww
     if ((!this->is_canonical) || (!std::filesystem::exists(this->filename)))
     {
+        // std::cout << "relation :" << this->get_filename()  << "not exists!";
         return;
     }
  
@@ -734,7 +739,9 @@ void relation::initialize_relation(mpi_comm& mcomm, std::map<u64, u64>& intern_m
 	    	load_data_from_file();
     }
     else
+    {
     	load_data_from_file();
+    }
     //std::cout << filename << " " << fact_load << std::endl;
     //if (fact_load == true)
         //if (init_val.size() != 0)

--- a/compiler/src/compile.rkt
+++ b/compiler/src/compile.rkt
@@ -134,16 +134,17 @@
                (error (format "Could not find an appropriate relation ~a with arity ~a (need 1 candidate, got ~a)" rel-name rel-arity (length maybe-relation))))
              (define relation (first maybe-relation))
              (match-define `(relation ,_ ,_ ,rid ,index ,data) relation)
-             (define tag-func (format "get_tag_for_rel(\"~a\",~a)" rel-name (rel->arity rel-sel)))
+             (define tag-func (format "get_tag_for_rel(\"~a\",\"~a\")" rel-name (string-join (map number->string sel) "__")))
+             (define is-canonical (canonical-index? (rel->sel rel-sel) (rel->arity rel-sel)))
              (string-append rel-txt
                             (format "relation* ~a = new relation(~a, ~a, ~a, ~a, ~a, ~a FULL);\n"
                                     (rel->name rel-sel)
                                     (length (rel->sel rel-sel))
-                                    (if (and (not (member 0 (rel->sel rel-sel))) (= (length (rel->sel rel-sel)) (rel->arity rel-sel))) "true" "false")
+                                    (if is-canonical "true" "false")
                                     (rel->arity rel-sel)
                                     tag-func
                                     (format "std::to_string(~a) + \".~a.~a.table\"" tag-func rel-name rel-arity)
-                                    (if (and (not (member 0 (rel->sel rel-sel))) (= (length (rel->sel rel-sel)) (rel->arity rel-sel)))
+                                    (if is-canonical
                                         (format "slog_input_dir + \"/\" + std::to_string(~a) + \".~a.~a.table\"," tag-func rel-name rel-arity)
                                         ; TODO: how to get rid of this space?????
                                         " ")
@@ -435,7 +436,9 @@
                             (define arg-pos-in-bvars1 (index-of new-indices (list-ref indices i)))
                             (define arg (list-ref bvars1 arg-pos-in-bvars1))
                             (match arg
-                              [(? lit?) (format "n2d(~a)" arg)]
+                              ; [(? lit?) (format "n2d(~a)" arg)]
+                              [(? string?) (format "n2d(\"~a\")" arg)]
+                              [(? number?)  (format "n2d(~a)" arg)]
                               [else 
                                 (define arg-pos-in-bvars0 (index-of bvars0 arg))
                                 (format "data[~a]" arg-pos-in-bvars0)])) 
@@ -490,7 +493,9 @@
                             (define arg-pos-in-bvars1 (index-of new-indices (list-ref indices i)))
                             (define arg (list-ref bvars1 arg-pos-in-bvars1))
                             (match arg
-                              [(? lit?) (format "n2d(~a)" arg)]
+                              ; [(? lit?) (format "n2d(~a)" arg)]
+                              [(? string?) (format "n2d(\"~a\")" arg)]
+                              [(? number?)  (format "n2d(~a)" arg)]
                               [else 
                                 (define arg-pos-in-bvars0 (index-of bvars0 arg))
                                 (format "data[~a]" arg-pos-in-bvars0)])) 
@@ -525,7 +530,9 @@
                             (define arg-pos-in-bvars1 (index-of new-indices (list-ref indices i)))
                             (define arg (list-ref bvars1 arg-pos-in-bvars1))
                             (match arg
-                              [(? lit?) (format "n2d(~a)" arg)]
+                              ; [(? lit?) (format "n2d(~a)" arg)]
+                              [(? string?) (format "n2d(\"~a\")" arg)]
+                              [(? number?)  (format "n2d(~a)" arg)]
                               [else 
                                 (define arg-pos-in-bvars0 (index-of bvars0 arg))
                                 (format "data[~a]" arg-pos-in-bvars0)])) 

--- a/compiler/src/daemondriver-template.cpp
+++ b/compiler/src/daemondriver-template.cpp
@@ -1,4 +1,7 @@
 #include "parallel_RA_inc.h"
+#include <iterator>
+#include <sstream>
+#include <string>
 
 // builtins.cpp goes here!
 ~a
@@ -27,22 +30,32 @@ void load_input_relation(std::string db_dir)
     std::string filename_s = entry.path().stem().string();
     int tag = std::stoi(filename_s.substr(0, filename_s.find(".")));
     std::string name_arity = filename_s.substr(filename_s.find(".")+1, filename_s.size()-filename_s.find(".")-1);
+    std::string name = name_arity.substr(0, name_arity.rfind("."));
+    std::string arity_s = name_arity.substr(name_arity.rfind(".")+1, name_arity.size());
+    int arity = std::stoi(arity_s);
+    std::stringstream index_stream;
+    index_stream << name;
+    for (int i = 1; i <= arity; i++)
+    {
+      index_stream << "__" <<  i;
+    }
     if (tag > max_rel)
       max_rel = tag;
-    rel_tag_map[name_arity] = tag;
+    std::cout << "load " << index_stream.str() << std::endl;
+    rel_tag_map[index_stream.str()] = tag;
   }
 }
 
-int get_tag_for_rel(std::string relation_name, int arity) {
-  std::string name_arity = relation_name + "." + std::to_string(arity);
+int get_tag_for_rel(std::string relation_name, std::string index_str) {
+  std::string name_arity = relation_name + "__" + index_str;
   if (rel_tag_map.find(name_arity) != rel_tag_map.end())
   {
-    std::cout << "rel: " << name_arity << rel_tag_map[name_arity] << std::endl;
+    // std::cout << "rel: " << name_arity << " " << rel_tag_map[name_arity] << std::endl;
     return rel_tag_map[name_arity];
   }
   max_rel++;
   rel_tag_map[name_arity] = max_rel;
-  std::cout << "rel: " << name_arity << " " << max_rel << std::endl;
+  std::cout << "generate rel tag: " << name_arity << " " << max_rel << std::endl;
   return max_rel;
 }
 

--- a/compiler/src/lang-predicates.rkt
+++ b/compiler/src/lang-predicates.rkt
@@ -714,7 +714,7 @@
 
 ; A canonical index must include all the columns from 1 to N and not include 0
 (define (canonical-index? l arity)
-  (equal? (sort l <) (range 1 (add1 arity))))
+  (equal? l (range 1 (add1 arity))))
 
 ; Strips out any/all prov information in an s-expr
 (define (strip-prov e)


### PR DESCRIPTION
In original code we think  relation (foo a b) has arity 2,  index `1__2`  and index `2__1` both canonical index.
During I/O in backend, both 2 relation will take input file `1.foo.2.table` as input/output file, which can cause wrong result.
also in old code base,   index `1__2`  and index `2__1` has same relation tag which is wrong.

This PR fix above problem 

