### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update -y
 RUN apt-get install -y valgrind apt-utils
 
 ENV OMPI_ALLOW_RUN_AS_ROOT=1
+ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
 ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 ENV CC=mpicc
 ENV CXX=mpicxx


### PR DESCRIPTION
solve `Error -1, errno = 0` caused by openmpi  vader error in docker