### PR TITLE
fix  fact  input error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ __pycache__
 parser.out
 parsertab.py
 TESTOUT
-.vscode
+.vscode/c_cpp_properties.json
+.vscode/settings.json
 .slog-history
 metadatabase/database.sqlite3
 env/
@@ -18,3 +19,6 @@ temp-out/
 test-input
 souffle-out
 
+temp-out/
+test-input
+souffle-out

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "run-test",
+            "type": "shell",
+            "command": "docker build -t stargazermiao/slog . && docker run -it --rm --entrypoint bash stargazermiao/slog /slog/slog/tests/run_test.sh size_compare 6"
+        },
+        {
+            "label": "docker-build",
+            "type": "shell",
+            "command": "docker build -t stargazermiao/slog ."
+        }
+    ]
+}

--- a/backend/src/RAM/RA_tasks.cpp
+++ b/backend/src/RAM/RA_tasks.cpp
@@ -498,17 +498,15 @@ u32 RAM::local_compute(int* offset)
         {
             fact* current_ra = (fact*) *it;
             relation* fact_relation = current_ra->get_relation();
-            std::vector<u64> data = current_ra->get_init_data();
-            if (mcomm.get_rank()==0)
-                current_ra->init_with_fact(get_bucket_count(),
-                                       fact_relation->get_sub_bucket_per_bucket_count(),
-                                       fact_relation->get_sub_bucket_rank(),
-                                       fact_relation->get_arity(),
-                                       fact_relation->get_join_column_count(),
-                                       fact_relation->get_is_canonical(),
-                                       data,
-                                       compute_buffer,
-                                       counter);
+            // if (mcomm.get_rank()==0)
+            current_ra->init_with_fact(get_bucket_count(),
+                                    fact_relation->get_sub_bucket_per_bucket_count(),
+                                    fact_relation->get_sub_bucket_rank(),
+                                    fact_relation->get_arity(),
+                                    fact_relation->get_join_column_count(),
+                                    fact_relation->get_is_canonical(),
+                                    compute_buffer,
+                                    counter);
         }
 
 

--- a/slog/common/client.py
+++ b/slog/common/client.py
@@ -380,7 +380,7 @@ class SlogClient:
         tupcnt_col_len = max(len(tupcnt_hdr) + 2, max_name_length + 2)
         arity_hdr = "Arity  "
         arity_hdr_len = len(arity_hdr)
-        header = f"{name_hdr: <{name_col_length}}{arity_hdr}{tupcnt_hdr: <{tupcnt_col_len}}Tag    Size (MiB)\n"
+        header = f"{name_hdr: <{name_col_length}}{arity_hdr}{tupcnt_hdr: <{tupcnt_col_len}}Tag    Size (KiB)\n"
         writer.write(header)
         screen_out = ""
         for rel in sorted(self.relations, key=lambda rel: rel[3]*rel[1]):

--- a/slog/tests/run_test.sh
+++ b/slog/tests/run_test.sh
@@ -14,4 +14,4 @@ fi
 
 sleep 4
 
-python3 -m slog.tests.$1
+python3 -m slog.tests.$1 --cores ${2:-1}

--- a/slog/tests/size_compare.py
+++ b/slog/tests/size_compare.py
@@ -1,13 +1,12 @@
 """
 A CI test for a slog compiler only check the output size
-
 Yihao Sun
 """
 
+from argparse import ArgumentParser
 import os
 import subprocess
 import shutil
-from tempfile import tempdir
 from slog.daemon.util import get_relation_info
 
 from slog.tests.test import Test
@@ -21,7 +20,8 @@ class SizeCompareTest(Test):
     """
     Test if backend compiler produce correct size
     """
-    def __init__(self):
+    def __init__(self, cores):
+        self.cores = cores
         super().__init__("localhost", ("Backend integration test"))
 
     def check_count(self, test_name, slogpath, factpath, expected_counts):
@@ -31,9 +31,9 @@ class SizeCompareTest(Test):
         if not os.path.exists(out_dir):
             os.makedirs(out_dir)
         try:
-            # print([RUNSLOG_PATH, "-v", "-j", "4", "-f", factpath, slogpath, f"{WORKDIR}/out"])
             exec_out = subprocess.check_output(
-                [RUNSLOG_PATH, "-ov", "-v", "-f", factpath, slogpath, out_dir],
+                [RUNSLOG_PATH, "-ov", "-v", "-j", str(self.cores),
+                "-f", factpath, slogpath, out_dir],
                  stderr=subprocess.STDOUT)
             print(exec_out.decode())
         except subprocess.CalledProcessError as e:
@@ -77,4 +77,9 @@ class SizeCompareTest(Test):
         #     shutil.rmtree(f"{WORKDIR}/out")
         # self.success()
 
-SizeCompareTest().test()
+if __name__ == "__main__":
+    parser = ArgumentParser("Fact size compare testing.")
+    parser.add_argument("--cores", help="number of cores to run the test",
+                        type=int, dest="cores", default=1)
+    args = parser.parse_args()
+    SizeCompareTest(args.cores).test()


### PR DESCRIPTION
Fix  input facts related facts:
-  `fact` RA operation only apply on rank 0 which will cause literal facts throw a MPI error. Related testcase: `stringtest` fail on core > 2
- fix a implicit u64 type conversion in `parallel_IO.cc`. It may cause c++ compiler undefined behavior on some compilers (e.g. gcc 8) , which may lead to a fact count error
- allow test harness accept multi cores setting
-  add a vscode task setting
